### PR TITLE
add bearer token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+.idea/

--- a/client.go
+++ b/client.go
@@ -16,11 +16,12 @@ import (
 
 // Client for the Confluence API
 type Client struct {
-	Cookie   string
-	Username string
-	Password string
-	Endpoint string
-	Debug    bool
+	Cookie      string
+	Username    string
+	Password    string
+	AccessToken string
+	Endpoint    string
+	Debug       bool
 }
 
 func (client *Client) request(method string, apiEndpoint string, queryParams string, payloadString string) ([]byte, error) {
@@ -48,6 +49,8 @@ func (client *Client) request(method string, apiEndpoint string, queryParams str
 
 	if client.Cookie != "" {
 		req.Header.Set("Cookie", fmt.Sprintf("JSESSIONID=%v", client.Cookie))
+	} else if client.AccessToken != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", client.AccessToken))
 	} else {
 		req.SetBasicAuth(client.Username, client.Password)
 	}


### PR DESCRIPTION
## Overview
This simply adds Bearer token to Authorization header to support [Personal Access Tokens](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html) in Confluence.